### PR TITLE
chore(releases): prepare a new release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+### Login As 1.9.3 - October 27, 2016 ###
+ * fix(menus): do not register a menu item for non-admin users
+
 ### Login As 1.9.2 - September 3, 2015 ###
  * Fixes fatal error on logout
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -3,7 +3,7 @@
 	<id>login_as</id>
 	<name>Login As</name>
 	<author>Brett Profitt</author>
-	<version>1.9.2</version>
+	<version>1.9.3</version>
 	<category>admin</category>
 	<category>bundled</category>
 	<description>Allows admin users to login as another user.</description>


### PR DESCRIPTION
We didn't tag a release for a year, so the latest fix never gets pulled.
- [ ] Tag a release after merging
