### PR TITLE
fix(action): remove empty register_error() call

### DIFF
--- a/actions/login_as.php
+++ b/actions/login_as.php
@@ -36,8 +36,6 @@ try {
 	$session->remove('login_as_original_user_guid');
 	$session->remove('login_as_original_persistent');
 
-	register_error();
-
 	try {
 		login($original_user);
 	} catch (Exception $ex) {


### PR DESCRIPTION
In case of an exception an empty register_error() call resulted in a fatal
error due to missing argument