### PR TITLE
fix(menus): do not add login_as menu item for banned users

### DIFF
--- a/classes/Elgg/LoginAs/UserHoverMenuHandler.php
+++ b/classes/Elgg/LoginAs/UserHoverMenuHandler.php
@@ -23,6 +23,11 @@ class UserHoverMenuHandler {
 			return;
 		}
 
+		if ($user->isBanned()) {
+			// banned users are unable to login
+			return;
+		}
+
 		if (!$logged_in_user || !$logged_in_user->isAdmin()) {
 			return;
 		}


### PR DESCRIPTION
Since banned users can not login, adding a login as link to banned user menu
does nothing.